### PR TITLE
[W-13207777] get raw from reference id

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-schema-document",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-schema-document",
   "description": "A component to render XML schema with examples",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiSchemaDocument.js
+++ b/src/ApiSchemaDocument.js
@@ -25,7 +25,7 @@ export class ApiSchemaDocument extends AmfHelperMixin(LitElement) {
     }`;
   }
 
-  
+
 
   static get properties() {
     return {
@@ -149,7 +149,7 @@ export class ApiSchemaDocument extends AmfHelperMixin(LitElement) {
 
   /**
    * @param {any} schema
-   * @return {string} 
+   * @return {string}
    */
   _computeRawValue(schema) {
     let raw = /** @type string */ (this._getValue(schema, this.ns.aml.vocabularies.document.raw));
@@ -159,6 +159,13 @@ export class ApiSchemaDocument extends AmfHelperMixin(LitElement) {
     if (!raw) {
       // @ts-ignore
       raw = this._computeSourceMapsSchema(schema);
+    }
+    if (!raw) {
+      const referenceIdKey = this._getAmfKey(this.ns.aml.vocabularies.document.referenceId);
+      const referenceIdData = this._ensureArray(schema[referenceIdKey]);
+      if (Array.isArray(referenceIdData) && referenceIdData.length > 0) {
+        raw = (this._getValue(referenceIdData[0], this.ns.aml.vocabularies.document.raw));
+      }
     }
     return raw;
   }


### PR DESCRIPTION
### Issue
A Content of schema type is not displayed.



The issue is with the following schema "itemStatusResponseXsd" that has been well referenced in the following API Specs: "ext-p-item-management-api"



Steps to reproduce:

Import attached spec
Navigate to itemStatusResponseXsd type
See that the documentation is empty

### Solution
- Got raw XML from the reference-id 

### Screenshots 

https://github.com/arc-archive/api-schema-document/assets/96145153/982eab04-4000-422a-a768-d47f2026bd91

